### PR TITLE
Polyfill ES2015 Proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "deepmerge": "^1.3.2",
+    "es2015-proxy": "^0.1.7",
     "react": "^15.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
     "type": "git",
     "url": "git://github.com/notsunohito/orex.git"
   },
+  "bugs": {
+    "url": "https://github.com/notsunohito/orex/issues"
+  },
   "author": "Shuichiro Kamiya",
   "license": "MIT",
+  "engines" : {
+    "node" : ">=6.4.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/src/actionProxy/index.js
+++ b/src/actionProxy/index.js
@@ -1,3 +1,4 @@
+import Proxy from 'es2015-proxy'
 import {
     update,
     replace,


### PR DESCRIPTION
https://babeljs.io/learn-es2015/#ecmascript-2015-features-proxies

# Proxy
> Unsupported feature
> Due to the limitations of ES5, Proxies cannot be transpiled or polyfilled. See support in various > JavaScript engines.